### PR TITLE
Use AC_CONFIG_MACRO_DIRS / ACLOCAL_AMFLAGS.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,5 @@
+ACLOCAL_AMFLAGS=-I m4
+
 cfgdir = $(sysconfdir)/sonic
 cfg_SCRIPTS = cfg/*.xml
 

--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,7 @@ AC_PREREQ([2.69])
 AC_INIT([libsonic-nas-platform-vm],[1.0.1],[sonicproject@gmail.com])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([src])
+AC_CONFIG_MACRO_DIRS([m4])
 
 # Checks for programs.
 AC_PROG_CXX


### PR DESCRIPTION
Avoid configure / libtool warnings by specifying directory for m4 macros.
